### PR TITLE
Add group selector & routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "polished": "^3.5.0",
     "react": "^16.4.1",
     "react-dom": "^16.0.1",
+    "react-router-dom": "^5.1.2",
     "styled-components": "^5.0.1"
   },
   "scripts": {
@@ -16,6 +17,7 @@
     "@types/node": "^10.5.5",
     "@types/react": "^16.8.16",
     "@types/react-dom": "^16.8.4",
+    "@types/react-router-dom": "^5.1.3",
     "@types/styled-components": "^5.0.1",
     "awesome-typescript-loader": "^5.2.0",
     "html-webpack-plugin": "^3.2.0",

--- a/src/main/resources/db/migration/V3__add-group-name-urlName.sql
+++ b/src/main/resources/db/migration/V3__add-group-name-urlName.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "group"
+ADD "name" text NOT NULL DEFAULT '',
+ADD "urlName" text NULL UNIQUE;
+
+UPDATE "group" SET "urlName" = "id";
+
+ALTER TABLE "group"
+ALTER "name" DROP DEFAULT,
+ALTER "urlName" SET NOT NULL;

--- a/src/main/scala/leaderboard/group/Group.scala
+++ b/src/main/scala/leaderboard/group/Group.scala
@@ -2,7 +2,16 @@ package leaderboard.group
 
 import leaderboard.common.Id
 
+import io.circe.Encoder
+import io.circe.generic.semiauto._
+
 final case class Group(
   id: Id[Group],
+  name: String,
+  urlName: String,
   password: PasswordHash
 )
+
+object Group {
+  implicit val encoder: Encoder[Group] = deriveEncoder
+}

--- a/src/main/scala/leaderboard/group/GroupApi.scala
+++ b/src/main/scala/leaderboard/group/GroupApi.scala
@@ -1,0 +1,16 @@
+package leaderboard.group
+
+import leaderboard.common.Api
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+
+class GroupApi(groupService: GroupService) extends Api {
+
+  val route: Route =
+    (get & path("groups")) {
+      complete {
+        groupService.getAll
+      }
+    }
+}

--- a/src/main/scala/leaderboard/group/GroupRepository.scala
+++ b/src/main/scala/leaderboard/group/GroupRepository.scala
@@ -9,20 +9,29 @@ import slick.lifted.ProvenShape
 
 private class GroupTable(tag: Tag) extends Table[Group](tag, "group") {
   def id: Rep[Id[Group]] = column[Id[Group]]("id", AutoInc)
+  def name: Rep[String] = column[String]("name")
+  def urlName: Rep[String] = column[String]("urlName")
   def password: Rep[String] = column[String]("password")
 
-  def * : ProvenShape[Group] = (id, password) <> (
-    { case (id, password) => Group(id, PasswordHash(password)) },
-    (group: Group) => Some((group.id, group.password.value))
+  def * : ProvenShape[Group] = (id, name, urlName, password) <> (
+    { case (id, name, urlName, password) => Group(id, name, urlName, PasswordHash(password)) },
+    (group: Group) => Some((group.id, group.name, group.urlName, group.password.value))
   )
 }
 
 class GroupRepository {
 
+  def getAll: DBIO[Seq[Group]] =
+    ordered.result
+
   def getById(groupId: Id[Group]): DBIO[Option[Group]] =
     byId(groupId).result.headOption
 
   private val table = TableQuery[GroupTable]
+
+  private val ordered = Compiled {
+    table.sortBy(_.id)
+  }
 
   private val byId = Compiled { groupId: Rep[Id[Group]] =>
     table.filter(_.id === groupId)

--- a/src/main/scala/leaderboard/group/GroupService.scala
+++ b/src/main/scala/leaderboard/group/GroupService.scala
@@ -1,0 +1,14 @@
+package leaderboard.group
+
+import leaderboard.common.DatabaseProfile
+
+import scala.concurrent.Future
+
+class GroupService(
+  database: DatabaseProfile.api.Database,
+  groupRepository: GroupRepository
+) {
+
+  def getAll: Future[Seq[Group]] =
+    database.run(groupRepository.getAll)
+}

--- a/src/main/scala/leaderboard/group/PasswordHash.scala
+++ b/src/main/scala/leaderboard/group/PasswordHash.scala
@@ -1,6 +1,7 @@
 package leaderboard.group
 
 import com.github.t3hnar.bcrypt.BCryptStrOps
+import io.circe.{Encoder, Json}
 
 final case class PasswordHash(value: String) extends AnyVal {
 
@@ -9,6 +10,7 @@ final case class PasswordHash(value: String) extends AnyVal {
 }
 
 object PasswordHash {
+  implicit val encoder: Encoder[PasswordHash] = Encoder.instance(_ => Json.Null)
 
   def fromRaw(password: String): PasswordHash =
     PasswordHash(password.bcrypt(rounds = 10))

--- a/src/main/typescript/Api.ts
+++ b/src/main/typescript/Api.ts
@@ -1,6 +1,6 @@
-import { useFakeData, fakeRatedGames, fakeDeletedGames } from "./FakeData"
+import { useFakeData, fakeRatedGames, fakeDeletedGames, fakeGroups } from "./FakeData"
 import { NewGame, RatedGame, Game, GameId } from "./Game"
-import { GroupId } from "./Group"
+import { GroupId, Group } from "./Group"
 
 export const getGames = (groupId: GroupId): Promise<ReadonlyArray<RatedGame>> =>
   useFakeData
@@ -21,6 +21,11 @@ export const updateGame = (gameId: GameId, newGame: NewGame): Promise<{}> =>
   useFakeData
     ? Promise.resolve({})
     : fetch(`/api/games/${gameId}`, put(newGame)).then(response => response.json())
+
+export const getGroups = (): Promise<ReadonlyArray<Group>> =>
+  useFakeData
+    ? Promise.resolve(fakeGroups)
+    : fetch("/api/groups").then(response => response.json())
 
 const post = (body: any): RequestInit =>
   ({

--- a/src/main/typescript/FakeData.ts
+++ b/src/main/typescript/FakeData.ts
@@ -1,4 +1,5 @@
 import { RatedGame, Game } from "./Game"
+import { Group } from "./Group"
 
 export const useFakeData: Boolean =
   new URLSearchParams(window.location.search).get('fakeData') !== null
@@ -237,7 +238,7 @@ export const fakeRatedGames: ReadonlyArray<RatedGame> =
       }
     },
     {
-      "game": { "id": "21", "groupId": "0", "playedAt": "2020-03-05T00:00", "player1": "Bbb", "player2": "E", "score1": 24, "score2": 0.5, "isDeleted": false },
+      "game": { "id": "22", "groupId": "0", "playedAt": "2020-03-05T00:00", "player1": "Bbb", "player2": "E", "score1": 24, "score2": 0.5, "isDeleted": false },
       "playerRatings": {
         "Dddddd": { "rating": 1327.98798861119, "deviation": 350 },
         "Ffffff": { "rating": 1392.1900544350583, "deviation": 350 },
@@ -253,4 +254,8 @@ export const fakeRatedGames: ReadonlyArray<RatedGame> =
 
 export const fakeDeletedGames: ReadonlyArray<Game> = [
   { "id": "22", "groupId": "0", "playedAt": "2020-03-06T00:00", "player1": "Bbb", "player2": "E", "score1": 12, "score2": 20, "isDeleted": true }
+]
+
+export const fakeGroups: ReadonlyArray<Group> = [
+  { "id": "0", "name": "Test Group", urlName: "test-group" }
 ]

--- a/src/main/typescript/Group.ts
+++ b/src/main/typescript/Group.ts
@@ -1,5 +1,7 @@
 export type GroupId = string
 
 export interface Group {
-  id: GroupId
+  id: GroupId,
+  name: string,
+  urlName: string
 }

--- a/src/main/typescript/components/AppReducer.ts
+++ b/src/main/typescript/components/AppReducer.ts
@@ -3,7 +3,8 @@ import { RatedGame, NewGame, Game } from "../Game"
 import { Group, GroupId } from "../Group"
 
 export interface State {
-  group: Group,
+  groups: ReadonlyArray<Group>,
+  openGroup?: Group,
   games: ReadonlyArray<RatedGame>,
   deletedGames: ReadonlyArray<Game>,
   selectedGameIndex: number,
@@ -13,7 +14,7 @@ export interface State {
 }
 
 export const initialState: State = {
-  group: { id: "0" },
+  groups: [],
   games: [],
   deletedGames: [],
   selectedGameIndex: 0,
@@ -21,7 +22,10 @@ export const initialState: State = {
 }
 
 export type Action =
-  { type: "gamesFetched", games: ReadonlyArray<RatedGame> }
+  { type: "groupsFetched", groups: ReadonlyArray<Group> }
+  | { type: "groupOpened", group: Group }
+  | { type: "groupClosed" }
+  | { type: "gamesFetched", games: ReadonlyArray<RatedGame> }
   | { type: "deletedGamesFetched", deletedGames: ReadonlyArray<Game> }
   | { type: "gameSelected", index: number }
   | { type: "playerToggled", player: string }
@@ -29,6 +33,12 @@ export type Action =
 
 export function reducer(state: State, action: Action): State {
   switch (action.type) {
+    case "groupsFetched":
+      return { ...state, groups: action.groups }
+    case "groupOpened":
+      return { ...state, openGroup: action.group }
+    case "groupClosed":
+      return { ...initialState, groups: state.groups }
     case "gamesFetched":
       if (action.games.length > 0) {
         const selectedGameIndex = action.games.length - 1
@@ -58,6 +68,10 @@ export function reducer(state: State, action: Action): State {
 }
 
 export type Dispatch = (_: Action) => void
+
+export function fetchGroups(dispatch: Dispatch): void {
+  Api.getGroups().then(groups => dispatch({ type: "groupsFetched", groups }))
+}
 
 export function fetchGames(dispatch: Dispatch, groupId: GroupId): void {
   Api.getGames(groupId).then(games => dispatch({ type: "gamesFetched", games }))

--- a/src/main/typescript/components/GroupSelectorPage.tsx
+++ b/src/main/typescript/components/GroupSelectorPage.tsx
@@ -1,0 +1,40 @@
+import * as React from "react"
+import { Link } from "react-router-dom"
+import styled from "styled-components"
+
+import { Group } from "../Group"
+
+export interface Props {
+  groups: ReadonlyArray<Group>
+}
+
+export function GroupSelectorPage({ groups }: Props) {
+  return <>
+    <h1>Groups</h1>
+
+    { groups.map(group =>
+        <GroupLink key={group.id} to={`/${group.urlName}`}>{group.name}</GroupLink>
+    ) }
+  </>
+}
+
+const GroupLink = styled(Link)`
+  display: block;
+  max-width: 320px;
+  margin-bottom: 1rem;
+  padding: 0.25rem 0.5rem;
+
+  border: 1px #ddd solid;
+  color: #222;
+  font-size: 18px;
+  font-weight: bold;
+  text-decoration: none;
+
+  &:visited {
+    color: #222;
+  }
+
+  &:hover {
+    background-color: #f7f7f7;
+  }
+`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
   ],
 
   devServer: {
+    historyApiFallback: true,
     proxy: {
       "/api": {
         target: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,7 +70,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.7.tgz#7b8facf95d25fef9534aad51c4ffecde1a61e26a"
   integrity sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==
 
-"@babel/runtime@^7.8.7":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.4.0", "@babel/runtime@^7.8.7":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
   integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
@@ -146,6 +146,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/history@*":
+  version "4.7.5"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.5.tgz#527d20ef68571a4af02ed74350164e7a67544860"
+  integrity sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==
+
 "@types/hoist-non-react-statics@*":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -191,6 +196,23 @@
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.61.23.tgz#bff4e0311c229a5203eb37aacd4febf59f3e2980"
   integrity sha512-upHmySsrVBDBokWWhYIKkKnpvadsHdioSjbBTu4xl7fjN0yb94KR5ngUOBXsyqAYqQzF+hP6qpvobG9M7Jr6hw==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^5.1.3":
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.3.tgz#b5d28e7850bd274d944c0fbbe5d57e6b30d71196"
+  integrity sha512-pCq7AkOvjE65jkGS5fQwQhvUp4+4PVD9g39gXLZViP2UqFiFzsEpB3PKf0O6mdbKsewSK8N14/eegisa/0CwnA==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.4.tgz#7d70bd905543cb6bcbdcc6bd98902332054f31a6"
+  integrity sha512-PZtnBuyfL07sqCJvGg3z+0+kt6fobc/xmle08jBiezLS8FrmGeiGkJnuxL/8Zgy9L83ypUhniV5atZn/L8n9MQ==
+  dependencies:
+    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.8.16":
@@ -1937,6 +1959,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
+
 handle-thing@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
@@ -2011,6 +2038,18 @@ he@1.2.x:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -2020,7 +2059,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -2432,6 +2471,11 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -2593,7 +2637,7 @@ loglevelnext@^1.0.1:
     es6-symbol "^3.1.1"
     object.assign "^4.1.0"
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -2751,6 +2795,15 @@ mimic-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+mini-create-react-context@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz#79fc598f283dd623da8e088b05db8cddab250189"
+  integrity sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==
+  dependencies:
+    "@babel/runtime" "^7.4.0"
+    gud "^1.0.0"
+    tiny-warning "^1.0.2"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -3206,6 +3259,13 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
+
 pbkdf2@^3.0.3:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
@@ -3429,10 +3489,44 @@ react-dom@^16.0.1:
     prop-types "^15.6.2"
     scheduler "^0.19.0"
 
+react-is@^16.6.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
   integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
+
+react-router-dom@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.1.2.tgz#06701b834352f44d37fbb6311f870f84c76b9c18"
+  integrity sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.1.2"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.1.2.tgz#6ea51d789cb36a6be1ba5f7c0d48dd9e817d3418"
+  integrity sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.3.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react@^16.4.1:
   version "16.13.0"
@@ -3565,6 +3659,11 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
   integrity sha1-six699nWiBvItuZTM17rywoYh0g=
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -4111,6 +4210,16 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tiny-invariant@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
@@ -4328,6 +4437,11 @@ v8-compile-cache@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"
   integrity sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
- Adds a new page/screen that lists all groups and links to the group pages.
- Adds routing, so appname.com is the group list and appname.com/groupname shows the group with that name.
- To support this, the `name` and `urlName` fields are added to `Group`, and a new endpoint is added for getting all groups.